### PR TITLE
Update aws_c_mqtt_jll to version 0.13.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsMqtt"
 uuid = "dbf63f58-971e-4a9b-b153-820e5f7f543b"
-version = "1.1.3"
+version = "1.1.4"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -21,7 +21,7 @@ LibAwsCompression = "1.1.0"
 LibAwsHTTP = "1.1.0"
 LibAwsIO = "1.1.0"
 LibAwsSdkutils = "1.1.0"
-aws_c_mqtt_jll = "=0.13.0"
+aws_c_mqtt_jll = "=0.13.1"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -18,4 +18,4 @@ aws_c_sdkutils_jll = "1282aa60-004d-510b-9f52-12498d409daa"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_mqtt_jll = "=0.13.0"
+aws_c_mqtt_jll = "=0.13.1"


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_mqtt_jll** to version **0.13.1**
- Updated **JuliaServices/LibAwsMqtt.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings